### PR TITLE
Update CSS Tree to semver version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "css-tree": "^1.0.0-alpha19",
+    "css-tree": "^1.0.0-alpha.19",
     "ramda": "^0.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
css-tree has updated its versioning to correct semver (latest version 1.0.0.aplha.26) ([link to issue](https://github.com/csstree/csstree/issues/59))
Update dependency to ^1.0.0.alpha.19 so that package no longer pulls incorrect version of css-tree